### PR TITLE
added hasRole and hasRoleAtLeast method for checking of user roles

### DIFF
--- a/src/Caffeinated/Shinobi/Traits/ShinobiTrait.php
+++ b/src/Caffeinated/Shinobi/Traits/ShinobiTrait.php
@@ -177,7 +177,7 @@ trait ShinobiTrait
 	/**
 	 * Check if user has at least one of the given roles
 	 *
-	 * @param  array   $roles
+	 * @param  array   $role
 	 * @return boolean
 	 */
 	public function hasRoleAtLeast(array $role)

--- a/src/Caffeinated/Shinobi/Traits/ShinobiTrait.php
+++ b/src/Caffeinated/Shinobi/Traits/ShinobiTrait.php
@@ -163,6 +163,33 @@ trait ShinobiTrait
 		return $can;
 	}
 
+	/**
+	 * Check if a user has role
+	 *
+	 * @param  string  $role
+	 * @return boolean
+	 */
+	public function hasRole($role)
+	{
+		return $this->hasRoleAtLeast([$role]);
+	}
+
+	/**
+	 * Check if user has at least one of the given roles
+	 *
+	 * @param  array   $roles
+	 * @return boolean
+	 */
+	public function hasRoleAtLeast(array $role)
+	{
+		$roles = $this->getRoles();
+
+		$intersection       = array_intersect($roles, $role);
+		$intersectionCount  = count($intersection);
+
+		return ($intersectionCount > 0) ? true : false;
+	}
+
 	/*
 	|----------------------------------------------------------------------
 	| Magic Methods


### PR DESCRIPTION
In Laravel 5.1, this method will be useful for checking roles via Middleware parameters like below:

```php
<?php

namespace App\Http\Middleware;

use Closure;

class RoleMiddleware
{
    /**
     * Handle an incoming request.
     *
     * @param  \Illuminate\Http\Request  $request
     * @param  \Closure  $next
     * @param  string $role
     * @return mixed
     */
    public function handle($request, Closure $next, $role)
    {
        if (! $request->user() || ! $request->user()->hasRole($role)) {
            if ($request->ajax()) {
                return response('Unauthorized.', 401);
            } else {
                return redirect()->guest('auth/login');
            }
        }

        return $next($request);
    }
}
```

```php
Route::get('test', ['middleware' => 'role:administrator', function() {
	return 'success';
}]);
```