### PR TITLE
Dynamic middleware feature

### DIFF
--- a/src/Caffeinated/Shinobi/Middleware/UserHasPermission.php
+++ b/src/Caffeinated/Shinobi/Middleware/UserHasPermission.php
@@ -9,12 +9,14 @@ class UserHasPermission
     {
         if (!Auth::user() || !Auth::user()->can($permission)) {
             // User doesn't have admin access
+
             if ($request->ajax()) {
+                // And the request was AJAX, so just die with a simple response.
                 return response('Unauthorized.', 401);
             }
 
             // Full stop.
-            return abort(403);
+            return abort(401);
         }
 
         return $next($request);

--- a/src/Caffeinated/Shinobi/Middleware/UserHasPermission.php
+++ b/src/Caffeinated/Shinobi/Middleware/UserHasPermission.php
@@ -1,0 +1,22 @@
+<?php namespace Caffeinated\Shinobi\Middleware;
+
+use Closure;
+use Illuminate\Support\Facades\Auth;
+
+class UserHasPermission
+{
+    public function handle($request, Closure $next, $permission)
+    {
+        if (!Auth::user() || !Auth::user()->can($permission)) {
+            // User doesn't have admin access
+            if ($request->ajax()) {
+                return response('Unauthorized.', 401);
+            }
+
+            // Full stop.
+            return abort(403);
+        }
+
+        return $next($request);
+    }
+}


### PR DESCRIPTION
This is a feature I use constantly in my applications, but it only works in Laravel 5.1 because of the new feature, middleware parameters.

To use, register middleware in your
`Http\Kernel.php`:

```php
protected $routeMiddleware = [
    // …
    'can' => 'Caffeinated\Shinobi\Middleware\UserHasPermission',
    // …
];
```

…then in your controller (or routes), call with the required permission
name:

```php
public function __construct()
{
    $this->middleware('can:permission_name’);
}
```