### PR TITLE
Fix compat with Laravel 5.2

### DIFF
--- a/src/Traits/ShinobiTrait.php
+++ b/src/Traits/ShinobiTrait.php
@@ -127,9 +127,10 @@ trait ShinobiTrait
 	 * Check if user has the given permission.
 	 *
 	 * @param  string $permission
+	 * @param array $arguments
 	 * @return bool
 	 */
-	public function can($permission)
+	public function can($permission, $arguments = [])
 	{
 		$can = false;
 


### PR DESCRIPTION
Without it, Laravel throws

Declaration of Caffeinated\Shinobi\Traits\ShinobiTrait::can($permission) should be compatible with Illuminate\Foundation\Auth\User::can($ability, $arguments = Array)