### PR TITLE
Reversed "no" and "all" access returns

### DIFF
--- a/src/Models/Role.php
+++ b/src/Models/Role.php
@@ -58,12 +58,12 @@ class Role extends Model
 	 */
 	public function can($permission)
 	{
-		if ($this->special === 'all-access') {
-			return true;
-		}
-
 		if ($this->special === 'no-access') {
 			return false;
+		}
+
+		if ($this->special === 'all-access') {
+			return true;
 		}
 
 		$permissions = $this->getPermissions();
@@ -87,12 +87,12 @@ class Role extends Model
 	 */
 	public function canAtLeast(array $permission = array())
 	{
-		if ($this->special === 'all-access') {
-			return true;
-		}
-
 		if ($this->special === 'no-access') {
 			return false;
+		}
+
+		if ($this->special === 'all-access') {
+			return true;
 		}
 
 		$permissions = $this->getPermissions();

--- a/src/Traits/ShinobiTrait.php
+++ b/src/Traits/ShinobiTrait.php
@@ -135,12 +135,12 @@ trait ShinobiTrait
 		$can = false;
 
 		foreach ($this->roles as $role) {
-			if ($role->special === 'all-access') {
-				return true;
-			}
-
 			if ($role->special === 'no-access') {
 				return false;
+			}
+
+			if ($role->special === 'all-access') {
+				return true;
 			}
 
 			if ($role->can($permission)) {
@@ -162,12 +162,12 @@ trait ShinobiTrait
 		$can = false;
 
 		foreach ($this->roles as $role) {
-			if ($role->special === 'all-access') {
-				return true;
-			}
-
 			if ($role->special === 'no-access') {
 				return false;
+			}
+
+			if ($role->special === 'all-access') {
+				return true;
 			}
 
 			if ($role->canAtLeast($permissions)) {


### PR DESCRIPTION
A banned admin should be banned. Changed to check for "banned" before granting for "admin".