### PR TITLE
Update for Laravel 5.2

### DIFF
--- a/src/Models/Role.php
+++ b/src/Models/Role.php
@@ -27,7 +27,7 @@ class Role extends Model
 	 */
 	public function users()
 	{
-		return $this->belongsToMany(Config::get('auth.model'))->withTimestamps();
+		return $this->belongsToMany(config('auth.model') ?: config('auth.providers.users.model'))->withTimestamps();
 	}
 
 	/**


### PR DESCRIPTION
Update for Laravel 5.2, also fix for "Class name must be a valid object or a string" error.