### PR TITLE
added several features & fixed a bug

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,5 +34,19 @@
             }
         }
     },
-    "minimum-stability": "dev"
+    "minimum-stability": "dev",
+    "require-dev": {
+        "phpunit/phpunit": "^6.4",
+        "squizlabs/php_codesniffer": "3.*",
+        "orchestra/testbench": "~3.0"
+    },
+    "autoload-dev": {
+        "psr-4": {
+             "Caffeinated\\Shinobi\\Tests\\": "tests/"
+        }
+    },
+    "scripts": {
+        "test": "vendor/bin/phpunit",
+         "cs": "vendor/bin/phpcs src/*"
+    }
 }

--- a/migrations/2017_10_17_170735_create_permission_user_table.php
+++ b/migrations/2017_10_17_170735_create_permission_user_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class CreatePermissionUserTable extends Migration
+{
+    public function up()
+    {
+        Schema::create('permission_user', function (Blueprint $table) {
+            $table->increments('id');
+            $table->integer('permission_id')->unsigned()->index();
+            $table->foreign('permission_id')->references('id')->on('permissions')->onDelete('cascade');
+            $table->integer('user_id')->unsigned()->index();
+            $table->foreign('user_id')->references('id')->on('users')->onDelete('cascade');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::drop('permission_user');
+    }
+
+}

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -1,0 +1,10 @@
+<?xml version="1.0"?>
+<ruleset name="Shinobi">
+
+    <description>A basic coding standard.</description>
+
+    <exclude-pattern>vendor/*</exclude-pattern>
+
+    <rule ref="PSR2" />
+
+</ruleset>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit backupGlobals="false"
+         backupStaticAttributes="false"
+         bootstrap="vendor/autoload.php"
+         colors="true"
+         convertErrorsToExceptions="true"
+         convertNoticesToExceptions="true"
+         convertWarningsToExceptions="true"
+         processIsolation="false"
+         stopOnFailure="false"
+         syntaxCheck="false"
+>
+    <testsuites>
+        <testsuite name="Package Test Suite">
+            <directory suffix=".php">./tests/</directory>
+        </testsuite>
+    </testsuites>
+    <filter>
+        <blacklist>
+            <directory suffix=".php">./vendor</directory>
+        </blacklist>
+    </filter>
+</phpunit>

--- a/src/Models/Role.php
+++ b/src/Models/Role.php
@@ -4,9 +4,12 @@ namespace Caffeinated\Shinobi\Models;
 
 use Config;
 use Illuminate\Database\Eloquent\Model;
+use Caffeinated\Shinobi\Traits\PermissionTrait;
 
 class Role extends Model
 {
+    use PermissionTrait;
+
     /**
      * The attributes that are fillable via mass assignment.
      *
@@ -22,11 +25,11 @@ class Role extends Model
     protected $table = 'roles';
 
     /**
-     * The cache tag used by the model.
+     * The shinobi cache tag used by the model.
      *
      * @var string
      */
-    protected $tag = 'shinobi.roles';
+    protected static $shinobi_tag = 'shinobi.roles';
 
     /**
      * Roles can belong to many users.
@@ -39,31 +42,12 @@ class Role extends Model
     }
 
     /**
-     * Roles can have many permissions.
-     *
-     * @return Model
-     */
-    public function permissions()
-    {
-        return $this->belongsToMany('\Caffeinated\Shinobi\Models\Permission')->withTimestamps();
-    }
-
-    /**
      * Get permission slugs assigned to role.
      *
      * @return array
      */
-    public function getPermissions()
+    protected function allPermissions()
     {
-        $primaryKey = $this[$this->primaryKey];
-        $cacheKey   = 'caffeinated.shinobi.permissions.'.$primaryKey;
-
-        if (method_exists(app()->make('cache')->getStore(), 'tags')) {
-            return app()->make('cache')->tags($this->tag)->remember($cacheKey, 60, function () {
-                return $this->permissions->pluck('slug')->all();
-            });
-        }
-
         return $this->permissions->pluck('slug')->all();
     }
 
@@ -74,9 +58,7 @@ class Role extends Model
      */
     public function flushPermissionCache()
     {
-        if (method_exists(app()->make('cache')->getStore(), 'tags')) {
-            app()->make('cache')->tags($this->tag)->flush();
-        }
+        parent::flushPermissionCache([static::$shinobi_tag, \Caffeinated\Shinobi\Traits\ShinobiTrait::$shinobi_tag]);
     }
 
     /**
@@ -96,17 +78,7 @@ class Role extends Model
             return true;
         }
 
-        $permissions = $this->getPermissions();
-
-        if (is_array($permission)) {
-            $permissionCount   = count($permission);
-            $intersection      = array_intersect($permissions, $permission);
-            $intersectionCount = count($intersection);
-
-            return ($permissionCount == $intersectionCount) ? true : false;
-        } else {
-            return in_array($permission, $permissions);
-        }
+        return $this->hasAllPermissions($permission, $this->getPermissions());
     }
 
     /**
@@ -126,71 +98,6 @@ class Role extends Model
             return true;
         }
 
-        $permissions = $this->getPermissions();
-
-        $intersection      = array_intersect($permissions, $permission);
-        $intersectionCount = count($intersection);
-
-        return ($intersectionCount > 0) ? true : false;
-    }
-
-    /**
-     * Assigns the given permission to the role.
-     *
-     * @param int $permissionId
-     *
-     * @return bool
-     */
-    public function assignPermission($permissionId = null)
-    {
-        $permissions = $this->permissions;
-
-        if (!$permissions->contains($permissionId)) {
-            $this->flushPermissionCache();
-
-            return $this->permissions()->attach($permissionId);
-        }
-
-        return false;
-    }
-
-    /**
-     * Revokes the given permission from the role.
-     *
-     * @param int $permissionId
-     *
-     * @return bool
-     */
-    public function revokePermission($permissionId = '')
-    {
-        $this->flushPermissionCache();
-
-        return $this->permissions()->detach($permissionId);
-    }
-
-    /**
-     * Syncs the given permission(s) with the role.
-     *
-     * @param array $permissionIds
-     *
-     * @return bool
-     */
-    public function syncPermissions(array $permissionIds = [])
-    {
-        $this->flushPermissionCache();
-
-        return $this->permissions()->sync($permissionIds);
-    }
-
-    /**
-     * Revokes all permissions from the role.
-     *
-     * @return bool
-     */
-    public function revokeAllPermissions()
-    {
-        $this->flushPermissionCache();
-
-        return $this->permissions()->detach();
+        return $this->hasAnyPermission($permission, $this->getPermissions());
     }
 }

--- a/src/Models/Role.php
+++ b/src/Models/Role.php
@@ -27,9 +27,12 @@ class Role extends Model
     /**
      * The shinobi cache tag used by the model.
      *
-     * @var string
+     * @return string
      */
-    protected static $shinobi_tag = 'shinobi.roles';
+    protected static function getShinobiTag()
+    {
+        return 'shinobi.roles';
+    }
 
     /**
      * Roles can belong to many users.
@@ -42,11 +45,11 @@ class Role extends Model
     }
 
     /**
-     * Get permission slugs assigned to role.
+     * Get fresh permission slugs assigned to role from database.
      *
      * @return array
      */
-    protected function allPermissions()
+    protected function getFreshPermissions()
     {
         return $this->permissions->pluck('slug')->all();
     }
@@ -58,7 +61,10 @@ class Role extends Model
      */
     public function flushPermissionCache()
     {
-        parent::flushPermissionCache([static::$shinobi_tag, \Caffeinated\Shinobi\Traits\ShinobiTrait::$shinobi_tag]);
+        parent::flushPermissionCache([
+          static::getShinobiTag(),
+          \Caffeinated\Shinobi\Traits\ShinobiTrait::getShinobiTag()
+        ]);
     }
 
     /**

--- a/src/ShinobiServiceProvider.php
+++ b/src/ShinobiServiceProvider.php
@@ -3,6 +3,7 @@
 namespace Caffeinated\Shinobi;
 
 use Blade;
+use Illuminate\Foundation\Application;
 use Illuminate\Support\ServiceProvider;
 
 class ShinobiServiceProvider extends ServiceProvider
@@ -21,9 +22,13 @@ class ShinobiServiceProvider extends ServiceProvider
      */
     public function boot()
     {
-        $this->publishes([
-            __DIR__.'/../migrations' => $this->app->databasePath().'/migrations',
-        ], 'migrations');
+        if (version_compare(Application::VERSION, '5.3.0', '<')) {
+            $this->publishes([
+                __DIR__.'/../migrations' => $this->app->databasePath().'/migrations',
+            ], 'migrations');
+        } else {
+            $this->loadMigrationsFrom(__DIR__.'/../migrations');
+        }
 
         $this->registerBladeDirectives();
     }

--- a/src/Traits/PermissionTrait.php
+++ b/src/Traits/PermissionTrait.php
@@ -1,0 +1,160 @@
+<?php
+
+namespace Caffeinated\Shinobi\Traits;
+
+trait PermissionTrait
+{
+    /**
+     * Users and Roles can have many permissions
+     *
+     * @return Illuminate\Database\Eloquent\Model
+     */
+    public function permissions()
+    {
+        return $this->belongsToMany('\Caffeinated\Shinobi\Models\Permission')->withTimestamps();
+    }
+
+    /**
+     * Get (cached) permission slugs assigned to the user or role.
+     * Internal method, should be implemented by Model implementing this trait
+     *
+     * @return array
+     */
+    protected function allPermissions()
+    {
+    }
+
+    /**
+     * Wrapper for caching the permission slugs
+     *
+     * @return array
+     */
+    public function getPermissions()
+    {
+        $primaryKey = $this[$this->primaryKey];
+        $cacheKey   = 'caffeinated.'.substr(static::$shinobi_tag, 0, -1).'.permissions.'.$primaryKey;
+
+        if (method_exists(app()->make('cache')->getStore(), 'tags')) {
+            return app()->make('cache')->tags(static::$shinobi_tag)->remember($cacheKey, 60, function () {
+                return $this->allPermissions();
+            });
+        }
+
+        return $this->allPermissions();
+    }
+
+    /**
+     * Assigns the given permission to the user or role.
+     *
+     * @param int $permissionId
+     *
+     * @return bool
+     */
+    public function assignPermission($permissionId = null)
+    {
+        $permissions = $this->permissions;
+
+        if (!$permissions->contains($permissionId)) {
+            $this->flushPermissionCache();
+
+            return $this->permissions()->attach($permissionId);
+        }
+
+        return false;
+    }
+
+    /**
+     * Revokes the given permission from the user or role.
+     *
+     * @param int $permissionId
+     *
+     * @return bool
+     */
+    public function revokePermission($permissionId = '')
+    {
+        $this->flushPermissionCache();
+
+        return $this->permissions()->detach($permissionId);
+    }
+
+    /**
+     * Syncs the given permission(s) with the user or role.
+     *
+     * @param array $permissionIds
+     *
+     * @return bool
+     */
+    public function syncPermissions(array $permissionIds = [])
+    {
+        $this->flushPermissionCache();
+
+        return $this->permissions()->sync($permissionIds);
+    }
+
+    /**
+     * Revokes all permissions from the user or role.
+     *
+     * @return bool
+     */
+    public function revokeAllPermissions()
+    {
+        $this->flushPermissionCache();
+
+        return $this->permissions()->detach();
+    }
+
+    /**
+     * Flush the permission cache repository.
+     *
+     * @return void
+     */
+    public function flushPermissionCache(array $tags = null)
+    {
+        if (method_exists(app()->make('cache')->getStore(), 'tags')) {
+            if ($tags === null) {
+                $tags = [ static::$shinobi_tag ];
+            }
+
+            foreach ($tags as $tag) {
+                app()->make('cache')->tags($tag)->flush();
+            }
+        }
+    }
+
+    /**
+     * Check if the or all requested permissions are satisfied
+     *
+     * @param mixed $permission
+     * @param array $permissions
+     *
+     * @return bool
+     */
+    protected function hasAllPermissions($permission, array $permissions)
+    {
+        if (is_array($permission)) {
+            $permissionCount   = count($permission);
+            $intersection      = array_intersect($permissions, $permission);
+            $intersectionCount = count($intersection);
+
+            return ($permissionCount == $intersectionCount) ? true : false;
+        } else {
+            return in_array($permission, $permissions);
+        }
+    }
+
+    /**
+     * Check if one of the requested permissions are satisfied
+     *
+     * @param array $permission
+     * @param array $permissions
+     *
+     * @return bool
+     */
+    protected function hasAnyPermission(array $permission, array $permissions)
+    {
+        $intersection      = array_intersect($permissions, $permission);
+        $intersectionCount = count($intersection);
+
+        return ($intersectionCount > 0) ? true : false;
+    }
+}

--- a/src/Traits/PermissionTrait.php
+++ b/src/Traits/PermissionTrait.php
@@ -5,6 +5,17 @@ namespace Caffeinated\Shinobi\Traits;
 trait PermissionTrait
 {
     /**
+     * The shinobi cache tag used by the model.
+     * Should be implemented by Model using this trait
+     *
+     * @return string
+     */
+    protected static function getShinobiTag()
+    {
+        return '';
+    }
+
+    /**
      * Users and Roles can have many permissions
      *
      * @return Illuminate\Database\Eloquent\Model
@@ -15,12 +26,12 @@ trait PermissionTrait
     }
 
     /**
-     * Get (cached) permission slugs assigned to the user or role.
-     * Internal method, should be implemented by Model implementing this trait
+     * Get fresh permission slugs assigned to the user or role.
+     * Internal method, should be implemented by Model using this trait
      *
      * @return array
      */
-    protected function allPermissions()
+    protected function getFreshPermissions()
     {
     }
 
@@ -32,15 +43,15 @@ trait PermissionTrait
     public function getPermissions()
     {
         $primaryKey = $this[$this->primaryKey];
-        $cacheKey   = 'caffeinated.'.substr(static::$shinobi_tag, 0, -1).'.permissions.'.$primaryKey;
+        $cacheKey   = 'caffeinated.'.substr(static::getShinobiTag(), 0, -1).'.permissions.'.$primaryKey;
 
         if (method_exists(app()->make('cache')->getStore(), 'tags')) {
-            return app()->make('cache')->tags(static::$shinobi_tag)->remember($cacheKey, 60, function () {
-                return $this->allPermissions();
+            return app()->make('cache')->tags(static::getShinobiTag())->remember($cacheKey, 60, function () {
+                return $this->getFreshPermissions();
             });
         }
 
-        return $this->allPermissions();
+        return $this->getFreshPermissions();
     }
 
     /**
@@ -112,7 +123,7 @@ trait PermissionTrait
     {
         if (method_exists(app()->make('cache')->getStore(), 'tags')) {
             if ($tags === null) {
-                $tags = [ static::$shinobi_tag ];
+                $tags = [ static::getShinobiTag() ];
             }
 
             foreach ($tags as $tag) {

--- a/src/Traits/ShinobiTrait.php
+++ b/src/Traits/ShinobiTrait.php
@@ -9,9 +9,12 @@ trait ShinobiTrait
     /**
      * The shinobi cache tag used by the user model.
      *
-     * @var string
+     * @return string
      */
-    protected static $shinobi_tag = 'shinobi.users';
+    protected static function getShinobiTag()
+    {
+        return 'shinobi.users';
+    }
 
     /*
     |----------------------------------------------------------------------
@@ -148,11 +151,11 @@ trait ShinobiTrait
     }
 
     /**
-     * Get all user role permissions.
+     * Get all user role permissions fresh from database
      *
      * @return array|null
      */
-    protected function allPermissions()
+    protected function getFreshPermissions()
     {
         $permissions = [[], $this->getUserPermissions()];
 
@@ -231,14 +234,14 @@ trait ShinobiTrait
     {
         // Handle isRoleslug() methods
         if (starts_with($method, 'is') and $method !== 'is') {
-            $role = substr($method, 2);
+            $role = kebab_case(substr($method, 2));
 
             return $this->isRole($role);
         }
 
         // Handle canDoSomething() methods
         if (starts_with($method, 'can') and $method !== 'can') {
-            $permission = substr($method, 3);
+            $permission = kebab_case(substr($method, 3));
 
             return $this->can($permission);
         }

--- a/tests/Models/User.php
+++ b/tests/Models/User.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Caffeinated\Shinobi\Tests\Models;
+
+use Caffeinated\Shinobi\Traits\ShinobiTrait;
+use Illuminate\Database\Eloquent\Model;
+
+class User extends Model
+{
+    use ShinobiTrait;
+
+    /**
+     * The attributes that are mass assignable.
+     *
+     * @var array
+     */
+    protected $fillable = [
+        'name', 'email', 'password',
+    ];
+
+    /**
+     * The attributes that should be hidden for arrays.
+     *
+     * @var array
+     */
+    protected $hidden = [
+        'password', 'remember_token',
+    ];
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace Caffeinated\Shinobi\Tests;
+
+use Illuminate\Database\Schema\Blueprint;
+use Caffeinated\Shinobi\Tests\Models\User;
+use Caffeinated\Shinobi\Models\Role;
+use Caffeinated\Shinobi\Models\Permission;
+
+abstract class TestCase extends \Orchestra\Testbench\TestCase
+{
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $this->loadLaravelMigrations([]);
+        $this->artisan('migrate');
+
+        $this->seedDatabase();
+    }
+
+    protected function seedDatabase()
+    {
+        $user = [
+          'admin' =>    User::create(['name'  => 'Admin', 'password' => 'password', 'email' => 'admin@example.com']),
+          'user' =>     User::create(['name'  => 'User', 'password' => 'password', 'email' => 'user@example.com']),
+          'super' =>    User::create(['name'  => 'Super User', 'password' => 'password', 'email' => 'super_user@example.com']),
+          'disabled' => User::create([ 'name'  => 'Disabled User', 'password' => 'password', 'email' => 'disabled_user@example.com']),
+        ];
+        
+        $roles = [
+            'admin' =>      Role::create(['name' => 'Admin', 'slug' => 'admin']),
+            'user' =>       Role::create(['name' => 'User', 'slug' => 'user']),
+            'allaccess' =>  Role::create(['name' => 'Super Access', 'slug' => 'super', 'special' => 'all-access']),
+            'noaccess' =>   Role::create(['name' => 'No access', 'slug' => 'no-access', 'special' => 'no-access']),
+        ];
+        
+        $permission = [
+            'access' => Permission::create(['name' => 'Admin Access', 'slug' => 'access.admin']),
+            'view' =>   Permission::create(['name' => 'View Users', 'slug' => 'view.users']),
+            'edit' =>   Permission::create(['name' => 'Edit Users', 'slug' => 'edit.users']),
+            'email' =>  Permission::create(['name' => 'Email Users', 'slug' => 'email.users']),
+        ];
+
+        $roles['admin']->permissions()->attach($permission['access']);
+        $roles['admin']->permissions()->attach($permission['edit']);
+        $roles['user']->permissions()->attach($permission['view']);
+        $roles['noaccess']->permissions()->attach($permission['view']);
+
+        $user['admin']->roles()->attach(Role::all());
+        $user['user']->roles()->attach($roles['user']);
+        $user['user']->permissions()->attach($permission['email']);
+        $user['super']->roles()->attach($roles['allaccess']);
+        $user['disabled']->roles()->attach($roles['noaccess']);
+    }
+
+    /**
+     * Set up the environment.
+     *
+     * @param \Illuminate\Foundation\Application $app
+     */
+    protected function getEnvironmentSetUp($app)
+    {
+        $app['config']->set('app.debug', true);
+        $app['config']->set('database.default', 'sqlite');
+        $app['config']->set('database.connections.sqlite', [
+            'driver'   => 'sqlite',
+            'database' => ':memory:',
+            'prefix'   => '',
+        ]);
+    }
+
+    protected function getPackageProviders($app)
+    {
+        return [
+            \Caffeinated\Shinobi\ShinobiServiceProvider::class,
+        ];
+    }
+
+    protected function getPackageAliases($app)
+    {
+        return [
+            'Shinobi' => \Caffeinated\Shinobi\Facades\Shinobi::class,
+        ];
+    }
+}

--- a/tests/UserTest.php
+++ b/tests/UserTest.php
@@ -1,0 +1,127 @@
+<?php
+
+namespace Caffeinated\Shinobi\Tests\Unit;
+
+use Caffeinated\Shinobi\Tests\TestCase;
+use Caffeinated\Shinobi\Tests\Models\User;
+use Caffeinated\Shinobi\Models\Role;
+use Caffeinated\Shinobi\Models\Permission;
+
+class UserTest extends TestCase
+{
+  public function test_has_admin_role()
+  {
+    $user = User::where('name', 'Admin')->first();
+    
+    $this->assertTrue($user->isRole('admin'));
+    $this->assertTrue($user->isAdmin());
+  }
+  
+  public function test_can_access_one_permission()
+  {
+    $user = User::where('name', 'Admin')->first();
+    
+    $this->assertTrue($user->can('access.admin'));
+  }
+
+  public function test_can_access_all_permission_from_same_role()
+  {
+    $user = User::where('name', 'Admin')->first();
+    
+    $this->assertTrue($user->can(['access.admin', 'edit.users']));
+  }
+
+  public function test_can_access_all_permission_from_different_roles()
+  {
+    $user = User::where('name', 'Admin')->first();
+    
+    $this->assertTrue($user->can(['access.admin', 'edit.users', 'view.users']));
+  }
+
+  public function test_can_access_user_permission()
+  {
+    $user = User::where('name', 'User')->first();
+    $this->assertTrue($user->can('email.users'));
+  }
+
+  public function test_can_access_all_permission_from_user_and_role()
+  {
+    $user = User::where('name', 'User')->first();
+    
+    $this->assertTrue($user->can(['view.users', 'email.users']));
+  }
+
+  public function test_cant_access_all_permission()
+  {
+    $user = User::where('name', 'User')->first();
+    
+    $this->assertFalse($user->can(['access.admin']));
+  }
+
+  public function test_can_access_atleast_one_permission()
+  {
+    $user = User::where('name', 'User')->first();
+    
+    $this->assertTrue($user->canAtLeast(['edit.users', 'view.users']));
+  }
+
+  public function test_cant_access_atleast_one_permission()
+  {
+    $user = User::where('name', 'User')->first();
+
+    $this->assertFalse($user->canAtLeast(['access.admin', 'edit.users']));
+  }
+  
+  public function test_can_revoke_and_assign_role()
+  {
+    $user = User::where('name', 'User')->first();
+
+    $roleId = $user->roles()->first()->id;
+    $permission = $user->roles()->first()->permissions()->first()->slug;
+
+    $user->revokeRole($roleId);
+    $this->assertFalse($user->can($permission), 'User::revokeRoke failed');
+
+    $user->assignRole($roleId);
+    // not sure why, but $user->fresh() doesnt work here
+    $user = User::where('name', 'User')->first();
+    $this->assertTrue($user->can($permission), 'User::assignRole failed');
+
+    $user->revokeAllRoles();
+    $user = User::where('name', 'User')->first();
+    $this->assertFalse($user->can($permission), 'User::revokeAllRoles failed');
+
+    $user->syncRoles([$roleId]);
+    $user = User::where('name', 'User')->first();
+    $this->assertTrue($user->can($permission), 'User::syncRoles failed');
+  }
+  
+  public function test_can_revoke_and_assign_role_by_slug()
+  {
+    $user = User::where('name', 'User')->first();
+
+    $roleSlug = $user->roles()->first()->slug;
+    $permission = $user->roles()->first()->permissions()->first()->slug;
+
+    $user->revokeRole($roleSlug);
+    $this->assertFalse($user->can($permission), 'User::revokeRoke failed');
+
+    $user->assignRole($roleSlug);
+    $user = User::where('name', 'User')->first();
+    $this->assertTrue($user->can($permission), 'User::assignRole failed');
+  }
+  
+  public function test_special_all_access()
+  {
+    $user = User::where('name', 'Super User')->first();
+    
+    $this->assertTrue($user->can('doesnt-even-exist-and-super-still-has-access'));
+  }
+
+  public function test_special_no_access()
+  {
+    $user = User::where('name', 'Disabled User')->first();
+    
+    $this->assertFalse($user->can('view.users'));
+  }
+}


### PR DESCRIPTION
As I really wanted to be able to assign permissions to users as requested in #46 I took some time to implement that. Because it wasnt that hard to fix, I also implemented #58. If the `$roleId` passed to `assignRole`/`revokeRole` is _not_ numeric, it will lookup the role by its slug.

While I was busy I noticed there was a bug with the `can` method. If you checked for permissions from multiple roles, the can method would always fail as it would only check the permissions _per_ role. This PR also fixes that issue, mostly due to the addition of user permissions.

I also added some tests to make sure I didnt introduce any regressions (but if I missed a test case I still might have). Install the dev deps and run `composer test`. I also added a phpcs config to test for code-style errors, run `composer cs` to run phpcs