### PR TITLE
Some improvements

### DIFF
--- a/src/Concerns/HasPermissions.php
+++ b/src/Concerns/HasPermissions.php
@@ -42,16 +42,21 @@ trait HasPermissions
             try {
                 $model = $this->getPermissionModel();
 
-                $permission = $model->where('slug', $permission)->firstOrFail();
+                if(method_exists($model, 'firstOrFail'))
+                    $permission = $model->where('slug', $permission)->firstOrFail();
+                else //If its cached
+                    $permission = $model->where('slug', $permission)->first();
+                
             } catch (\Exception $e) {
-                // 
+
             }
         }
         
         // Check role permissions
         if (method_exists($this, 'hasPermissionThroughRole') and $this->hasPermissionThroughRole($permission)) {
-            return $this->hasPermissionThroughRole($permission);
+            return true;
         }
+
         
         // Check user permission
         if ($this->hasPermission($permission)) {
@@ -60,7 +65,7 @@ trait HasPermissions
 
         return false;
     }
-
+    
     /**
      * Give the specified permissions to the model.
      * 

--- a/src/Concerns/HasRolesAndPermissions.php
+++ b/src/Concerns/HasRolesAndPermissions.php
@@ -16,7 +16,7 @@ trait HasRolesAndPermissions
     protected function hasPermissionThroughRole($permission): bool
     {
         if ($this->hasRoles()) {
-            foreach ($this->roles as $role) {
+            foreach ($permission->roles as $role) {
                 if ($this->roles->contains($role)) {
                     return true;
                 }


### PR DESCRIPTION
**hasPermissionThroughRole Fix**.
The original script is missing the variable **$permission** and its throwing always true because if we iterate the roles and inside we are checking if the model contains the iteration.
Its better iterate and compare with the permission roles.

**Add fix when cache layer is enabled**
When we use the experimental cache layer my project got some bugs and catching the error it says the method firstOrFail not exists so i implement a condicional if the method exists in the model use it if not take the first saved instance.

Also i modify the **// Check role permissions** guard
If the user hasPermissionThroughRole then execute, so we dont need to return again the response if in the sentence returns true.

Sorry for my bad english.